### PR TITLE
Adds underscore character in regex for package names

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -530,7 +530,7 @@
       Justification: The Scala style guide recommends that package names conform to certain standards.
     -->
     <parameters>
-      <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+      <parameter name="regex"><![CDATA[^[a-z][A-Za-z_]*$]]></parameter>
     </parameters>
   </check>
   <check level="error" enabled="true" class="org.scalastyle.scalariform.PackageObjectNamesChecker">
@@ -540,7 +540,7 @@
       Justification: The Scala style guide recommends that package object names conform to certain standards.
     -->
     <parameters>
-      <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+      <parameter name="regex"><![CDATA[^[a-z][A-Za-z_]*$]]></parameter>
     </parameters>
   </check>
   <check level="error" enabled="true" class="org.scalastyle.scalariform.ParameterNumberChecker">


### PR DESCRIPTION
Adds underscore character in regex for package names, to support `custom_resources`.

From John on Slack:
<img width="810" alt="screenshot 2018-08-15 18 29 11" src="https://user-images.githubusercontent.com/99890/44181867-2120ed00-a0b9-11e8-9c2a-3566410bc5d1.png">

/cc @zendesk/bolt

### Risks

none